### PR TITLE
Add TOML codec implementation

### DIFF
--- a/codecs/toml/go.mod
+++ b/codecs/toml/go.mod
@@ -3,8 +3,8 @@ module github.com/go-orb/plugins/codecs/toml
 go 1.23.6
 
 require (
+	github.com/BurntSushi/toml v1.5.0
 	github.com/go-orb/go-orb v0.2.1
-	github.com/pelletier/go-toml/v2 v2.2.3
 )
 
 require github.com/cornelk/hashmap v1.0.8 // indirect

--- a/codecs/toml/go.mod
+++ b/codecs/toml/go.mod
@@ -1,0 +1,10 @@
+module github.com/go-orb/plugins/codecs/toml
+
+go 1.23.6
+
+require (
+	github.com/go-orb/go-orb v0.2.1
+	github.com/pelletier/go-toml/v2 v2.2.3
+)
+
+require github.com/cornelk/hashmap v1.0.8 // indirect

--- a/codecs/toml/go.sum
+++ b/codecs/toml/go.sum
@@ -1,14 +1,6 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cornelk/hashmap v1.0.8 h1:nv0AWgw02n+iDcawr5It4CjQIAcdMMKRrs10HOJYlrc=
 github.com/cornelk/hashmap v1.0.8/go.mod h1:RfZb7JO3RviW/rT6emczVuC/oxpdz4UsSB2LJSclR1k=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-orb/go-orb v0.2.1 h1:MUPo361IBDL5xObAESgOCPy4IlrJG+4YBGz6OuMKT1M=
 github.com/go-orb/go-orb v0.2.1/go.mod h1:5LP/2OY9b3N5eOsiVVdU3R78B7kIfNXYNjJi9o0Vbdg=
-github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
-github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/codecs/toml/go.sum
+++ b/codecs/toml/go.sum
@@ -1,0 +1,14 @@
+github.com/cornelk/hashmap v1.0.8 h1:nv0AWgw02n+iDcawr5It4CjQIAcdMMKRrs10HOJYlrc=
+github.com/cornelk/hashmap v1.0.8/go.mod h1:RfZb7JO3RviW/rT6emczVuC/oxpdz4UsSB2LJSclR1k=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-orb/go-orb v0.2.1 h1:MUPo361IBDL5xObAESgOCPy4IlrJG+4YBGz6OuMKT1M=
+github.com/go-orb/go-orb v0.2.1/go.mod h1:5LP/2OY9b3N5eOsiVVdU3R78B7kIfNXYNjJi9o0Vbdg=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/codecs/toml/toml.go
+++ b/codecs/toml/toml.go
@@ -1,0 +1,88 @@
+// Package toml implements a TOML Marshaler.
+package toml
+
+import (
+	"io"
+
+	"github.com/go-orb/go-orb/codecs"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+var _ codecs.Marshaler = (*Toml)(nil)
+
+func init() {
+	codecs.Register("toml", &Toml{})
+}
+
+// Toml implements the codecs.Marshaler interface. It can be used to encode/decode
+// toml files, or web requests.
+type Toml struct{}
+
+// Encode encodes "v" into byte sequence.
+func (t *Toml) Encode(v any) ([]byte, error) {
+	return toml.Marshal(v)
+}
+
+// Decode decodes "data" into "v".
+// "v" must be a pointer value.
+func (t *Toml) Decode(data []byte, v any) error {
+	return toml.Unmarshal(data, v)
+}
+
+// NewEncoder returns an Encoder which writes bytes sequence into "w".
+func (t *Toml) NewEncoder(w io.Writer) codecs.Encoder {
+	encoder := toml.NewEncoder(w)
+	return codecs.EncoderFunc(func(v any) error {
+		return encoder.Encode(v)
+	})
+}
+
+// NewDecoder returns a Decoder which reads byte sequence from "r".
+func (t *Toml) NewDecoder(r io.Reader) codecs.Decoder {
+	decoder := toml.NewDecoder(r)
+	return codecs.DecoderFunc(func(v any) error {
+		return decoder.Decode(v)
+	})
+}
+
+// Encodes returns if this codec is able to encode the given type.
+func (t *Toml) Encodes(v any) bool {
+	switch v.(type) {
+	case []string:
+		return true
+	case []byte:
+		return true
+	case []any:
+		return true
+	case map[string]any:
+		return true
+	case string:
+		return true
+	default:
+		return false
+	}
+}
+
+// Decodes returns if this codec is able to decode the given type.
+func (t *Toml) Decodes(v any) bool {
+	return t.Encodes(v)
+}
+
+// ContentTypes returns the content types the marshaller can handle.
+func (t *Toml) ContentTypes() []string {
+	return []string{
+		"application/toml",
+		"text/toml",
+	}
+}
+
+// String returns the codec name.
+func (t *Toml) String() string {
+	return "toml"
+}
+
+// Exts returns the common file extensions for this encoder.
+func (t *Toml) Exts() []string {
+	return []string{".toml", ".tml"}
+}


### PR DESCRIPTION
This PR adds a TOML codec implementation based on github.com/pelletier/go-toml/v2.

Similar to the existing YAML codec, the TOML codec:
- Implements the codecs.Marshaler interface
- Registers itself via init()
- Supports encoding/decoding of TOML content
- Returns appropriate content types and file extensions

This implementation helps resolve issue #44.