### PR TITLE
feat(server): Add metadata to registry nodes in entrypoint implementa…

### DIFF
--- a/client/orb/client.go
+++ b/client/orb/client.go
@@ -119,7 +119,7 @@ func (c *Client) selectNode(ctx context.Context, service string, opts *client.Ca
 	}
 
 	// Run the configured Selector to get a node from the resolved nodes.
-	node, err := opts.Selector(ctx, service, nodes, opts.PreferredTransports, opts.AnyTransport)
+	node, err := opts.Selector(ctx, service, nodes, opts.PreferredTransports, opts.AnyTransport, opts.Metadata)
 	if err != nil {
 		c.Logger().Error("Failed to resolve service", "error", err, "service", service)
 		return "", "", err

--- a/client/orb_transport/drpc/drpc_test.go
+++ b/client/orb_transport/drpc/drpc_test.go
@@ -51,12 +51,9 @@ func setupServer(sn string, metadata map[string]string) (*tests.SetupData, error
 	fileHInstance := new(filehandler.Handler)
 	fileHRegister := fileproto.RegisterFileServiceHandler(fileHInstance)
 
-	// 建立配置選項
 	options := []server.Option{
 		drpc.WithHandlers(echoHRegister, fileHRegister),
 	}
-
-	// 如果提供了 metadata，添加到選項中
 	if metadata != nil {
 		options = append(options, server.WithEntrypointMetadata(metadata))
 	}

--- a/client/orb_transport/grpc/grpc_test.go
+++ b/client/orb_transport/grpc/grpc_test.go
@@ -28,7 +28,7 @@ import (
 	_ "github.com/go-orb/plugins/log/slog"
 )
 
-func setupServer(sn string) (*tests.SetupData, error) {
+func setupServer(sn string, metadata map[string]string) (*tests.SetupData, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	setupData := &tests.SetupData{}
@@ -59,6 +59,7 @@ func setupServer(sn string) (*tests.SetupData, error) {
 		grpc.NewConfig(server.WithEntrypointName("grpc"),
 			grpc.WithHandlers(hRegister, fileHRegister),
 			grpc.WithInsecure(),
+			server.WithEntrypointMetadata(metadata),
 		), logger, reg)
 	if err != nil {
 		cancel()
@@ -66,7 +67,11 @@ func setupServer(sn string) (*tests.SetupData, error) {
 		return nil, err
 	}
 
-	ep2, err := grpc.New(grpc.NewConfig(server.WithEntrypointName("grpcs"), grpc.WithHandlers(hRegister, fileHRegister)), logger, reg)
+	ep2, err := grpc.New(
+		grpc.NewConfig(server.WithEntrypointName("grpcs"),
+			grpc.WithHandlers(hRegister, fileHRegister),
+			server.WithEntrypointMetadata(metadata),
+		), logger, reg)
 	if err != nil {
 		cancel()
 

--- a/client/orb_transport/http/http_test.go
+++ b/client/orb_transport/http/http_test.go
@@ -25,7 +25,7 @@ import (
 	_ "github.com/go-orb/plugins/log/slog"
 )
 
-func setupServer(sn string) (*tests.SetupData, error) {
+func setupServer(sn string, metadata map[string]string) (*tests.SetupData, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	setupData := &tests.SetupData{}
@@ -54,6 +54,7 @@ func setupServer(sn string) (*tests.SetupData, error) {
 			server.WithEntrypointName("http"),
 			http.WithHandlers(hRegister),
 			http.WithInsecure(),
+			server.WithEntrypointMetadata(metadata),
 		),
 		logger,
 		reg,
@@ -70,6 +71,7 @@ func setupServer(sn string) (*tests.SetupData, error) {
 			http.WithHandlers(hRegister),
 			http.WithInsecure(),
 			http.WithAllowH2C(),
+			server.WithEntrypointMetadata(metadata),
 		),
 		logger,
 		reg,

--- a/client/tests/tests.go
+++ b/client/tests/tests.go
@@ -375,7 +375,7 @@ func (s *TestSuite) TestMetadataFilter() {
 				context.Background(),
 				commonServerName,
 				&echo.CallRequest{Name: "test"},
-				client.WithMetadata(map[string]string{"region": region}),
+				client.WithRegistryMetadata("region", region),
 			)
 
 			s.Require().NoError(err, "Request with matching region should succeed")
@@ -387,7 +387,7 @@ func (s *TestSuite) TestMetadataFilter() {
 				context.Background(),
 				commonServerName,
 				&echo.CallRequest{Name: "test"},
-				client.WithMetadata(map[string]string{"region": "wrong-region"}),
+				client.WithRegistryMetadata("region", "wrong-region"),
 			)
 
 			s.Require().Error(err, "Request with non-matching region should fail")

--- a/client/tests/tests.go
+++ b/client/tests/tests.go
@@ -324,24 +324,18 @@ func (s *TestSuite) TestMetadata() {
 func (s *TestSuite) TestMetadataFilter() {
 	regions := []string{"as-1", "eu-1", "us-1"}
 
+	const commonServerName = "metadata-server"
+
 	setupDatas := make([]*SetupData, 0, len(regions))
-	clientTypes := make([]client.Type, 0, len(regions))
 
 	defer func() {
-		for _, cli := range clientTypes {
-			if stopErr := cli.Stop(context.Background()); stopErr != nil {
-				s.T().Logf("Error stopping client: %v", stopErr)
-			}
-		}
-
 		for _, setup := range setupDatas {
 			setup.Stop()
 		}
 	}()
 
 	for _, region := range regions {
-		serverName := "metadata-server-" + region
-		setupData, err := s.setupServer(serverName, map[string]string{"region": region})
+		setupData, err := s.setupServer(commonServerName, map[string]string{"region": region})
 		s.Require().NoError(err, "Server setup failed for region "+region)
 
 		s.Require().NoError(setupData.Registry.Start(setupData.Ctx),
@@ -353,26 +347,17 @@ func (s *TestSuite) TestMetadataFilter() {
 		}
 
 		setupDatas = append(setupDatas, setupData)
-
-		cli, err := client.New(nil, &types.Components{}, setupData.Logger, setupData.Registry)
-		s.Require().NoError(err, "Client creation failed for region "+region)
-
-		s.Require().NoError(cli.Start(setupData.Ctx),
-			"Client start failed for region "+region)
-
-		clientTypes = append(clientTypes, cli)
 	}
 
 	time.Sleep(time.Second)
 
-	for i, region := range regions {
-		serverName := "metadata-server-" + region
-		echoClient := echo.NewStreamsClient(clientTypes[i])
+	echoClient := echo.NewStreamsClient(s.client)
 
+	for _, region := range regions {
 		s.Run("Matching region "+region, func() {
 			resp, err := echoClient.Call(
 				context.Background(),
-				serverName,
+				commonServerName,
 				&echo.CallRequest{Name: "test"},
 				client.WithMetadata(map[string]string{"region": region}),
 			)
@@ -384,7 +369,7 @@ func (s *TestSuite) TestMetadataFilter() {
 		s.Run("Non-matching region for "+region, func() {
 			_, err := echoClient.Call(
 				context.Background(),
-				serverName,
+				commonServerName,
 				&echo.CallRequest{Name: "test"},
 				client.WithMetadata(map[string]string{"region": "wrong-region"}),
 			)

--- a/client/tests/tests.go
+++ b/client/tests/tests.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-orb/go-orb/client"
 	"github.com/go-orb/go-orb/codecs"
@@ -133,7 +134,7 @@ type TestSuite struct {
 
 	entrypoints []server.Entrypoint
 	ctx         context.Context
-	setupServer func(service string) (*SetupData, error)
+	setupServer func(service string, metadata map[string]string) (*SetupData, error)
 	stopServer  context.CancelFunc
 
 	// To create more clients in Benchmarks.
@@ -141,7 +142,8 @@ type TestSuite struct {
 }
 
 // NewSuite creates a new test suite.
-func NewSuite(setupServer func(service string) (*SetupData, error), transports []string, requests ...TestRequest) *TestSuite {
+func NewSuite(setupServer func(service string, metadata map[string]string) (*SetupData, error),
+	transports []string, requests ...TestRequest) *TestSuite {
 	s := new(TestSuite)
 
 	s.Transports = transports
@@ -174,7 +176,7 @@ type TestRequest struct {
 func (s *TestSuite) SetupSuite() {
 	var err error
 
-	setupData, err := s.setupServer(ServiceName)
+	setupData, err := s.setupServer(ServiceName, nil)
 	if err != nil {
 		s.Require().NoError(err, "while setting up the server")
 	}
@@ -218,7 +220,7 @@ func (s *TestSuite) TearDownSuite() {
 }
 
 func (s *TestSuite) doRequest(ctx context.Context, req *TestRequest, clientWire client.Type, transport string) {
-	opts := []client.CallOption{}
+	var opts []client.CallOption
 	if req.ContentType != "" {
 		opts = append(opts, client.WithContentType(req.ContentType))
 	}
@@ -314,6 +316,80 @@ func (s *TestSuite) TestMetadata() {
 			rspHandler, ok := responseMd["tracing-id"]
 			s.Require().True(ok, "Transport does not transport metadata - tracing-id")
 			s.Require().Equal("asfdjhladhsfashf", rspHandler)
+		})
+	}
+}
+
+// TestMetadataFilter tests if metadata gets filtered.
+func (s *TestSuite) TestMetadataFilter() {
+	regions := []string{"as-1", "eu-1", "us-1"}
+
+	setupDatas := make([]*SetupData, 0, len(regions))
+	clientTypes := make([]client.Type, 0, len(regions))
+
+	defer func() {
+		for _, cli := range clientTypes {
+			if stopErr := cli.Stop(context.Background()); stopErr != nil {
+				s.T().Logf("Error stopping client: %v", stopErr)
+			}
+		}
+
+		for _, setup := range setupDatas {
+			setup.Stop()
+		}
+	}()
+
+	for _, region := range regions {
+		serverName := "metadata-server-" + region
+		setupData, err := s.setupServer(serverName, map[string]string{"region": region})
+		s.Require().NoError(err, "Server setup failed for region "+region)
+
+		s.Require().NoError(setupData.Registry.Start(setupData.Ctx),
+			"Registry start failed for region "+region)
+
+		for _, ep := range setupData.Entrypoints {
+			s.Require().NoError(ep.Start(setupData.Ctx),
+				"Entrypoint start failed for region "+region)
+		}
+
+		setupDatas = append(setupDatas, setupData)
+
+		cli, err := client.New(nil, &types.Components{}, setupData.Logger, setupData.Registry)
+		s.Require().NoError(err, "Client creation failed for region "+region)
+
+		s.Require().NoError(cli.Start(setupData.Ctx),
+			"Client start failed for region "+region)
+
+		clientTypes = append(clientTypes, cli)
+	}
+
+	time.Sleep(time.Second)
+
+	for i, region := range regions {
+		serverName := "metadata-server-" + region
+		echoClient := echo.NewStreamsClient(clientTypes[i])
+
+		s.Run("Matching region "+region, func() {
+			resp, err := echoClient.Call(
+				context.Background(),
+				serverName,
+				&echo.CallRequest{Name: "test"},
+				client.WithMetadata(map[string]string{"region": region}),
+			)
+
+			s.Require().NoError(err, "Request with matching region should succeed")
+			s.Require().Equal("Hello test", resp.GetMsg(), "Unexpected response message")
+		})
+
+		s.Run("Non-matching region for "+region, func() {
+			_, err := echoClient.Call(
+				context.Background(),
+				serverName,
+				&echo.CallRequest{Name: "test"},
+				client.WithMetadata(map[string]string{"region": "wrong-region"}),
+			)
+
+			s.Require().Error(err, "Request with non-matching region should fail")
 		})
 	}
 }

--- a/registry/tests/tests.go
+++ b/registry/tests/tests.go
@@ -793,7 +793,7 @@ func (r *TestSuite) TestMetadataFiltering() {
 	r.Require().NoError(err)
 
 	// Manually filter for production services
-	prodServices := []*registry.Service{}
+	var prodServices []*registry.Service
 
 	for _, svc := range allServices {
 		// Skip non-test services (those not starting with orb.test.filter)

--- a/server/drpc/drpc.go
+++ b/server/drpc/drpc.go
@@ -139,6 +139,11 @@ func (s *Server) Transport() string {
 	return "drpc"
 }
 
+// Metadata returns the metadata of this entrypoint.
+func (s *Server) Metadata() map[string]string {
+	return s.config.Metadata
+}
+
 // EntrypointID returns the id of this entrypoint (node) in the registry.
 func (s *Server) EntrypointID() string {
 	return s.registry.ServiceName() + types.DefaultSeparator + s.config.Name
@@ -189,7 +194,7 @@ func (s *Server) registryService() *registry.Service {
 		ID:        s.EntrypointID(),
 		Address:   s.Address(),
 		Transport: s.Transport(),
-		Metadata:  make(map[string]string),
+		Metadata:  s.Metadata(),
 	}
 
 	return &registry.Service{

--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -249,6 +249,11 @@ func (s *Server) Transport() string {
 	return "grpc"
 }
 
+// Metadata returns the metadata of this entrypoint.
+func (s *Server) Metadata() map[string]string {
+	return s.config.Metadata
+}
+
 // EntrypointID returns the id of this entrypoint (node) in the registry.
 func (s *Server) EntrypointID() string {
 	return s.registry.ServiceName() + types.DefaultSeparator + s.config.Name
@@ -339,7 +344,7 @@ func (s *Server) registryService() *registry.Service {
 		ID:        s.EntrypointID(),
 		Address:   s.Address(),
 		Transport: s.Transport(),
-		Metadata:  make(map[string]string),
+		Metadata:  s.Metadata(),
 	}
 
 	eps := s.getEndpoints()

--- a/server/http/entrypoint.go
+++ b/server/http/entrypoint.go
@@ -309,6 +309,11 @@ func (s *Server) Transport() string {
 	return "http"
 }
 
+// Metadata returns the metadata of this entrypoint.
+func (s *Server) Metadata() map[string]string {
+	return s.config.Metadata
+}
+
 // EntrypointID returns the id (configured name) of this entrypoint in the registry.
 func (s *Server) EntrypointID() string {
 	return s.config.Name
@@ -384,7 +389,7 @@ func (s *Server) registryService() (*registry.Service, error) {
 		ID:        s.EntrypointID(),
 		Address:   s.Address(),
 		Transport: s.Transport(),
-		Metadata:  make(map[string]string),
+		Metadata:  s.Metadata(),
 	}
 
 	eps, err := s.getEndpoints()

--- a/server/memory/memory.go
+++ b/server/memory/memory.go
@@ -131,6 +131,11 @@ func (s *Server) EntrypointID() string {
 	return s.config.Name
 }
 
+// Metadata returns the metadata of this entrypoint.
+func (s *Server) Metadata() map[string]string {
+	return s.config.Metadata
+}
+
 // String returns the entrypoint type.
 func (s *Server) String() string {
 	return s.Type()


### PR DESCRIPTION
# Add metadata to registry nodes in entrypoint implementations

This PR ensures all entrypoint implementations properly pass their metadata to registry nodes during registration. It completes the metadata functionality requested in go-orb/go-orb#21 by connecting entrypoint configuration with client-side filtering.